### PR TITLE
add jsapi as a peerDependency, make gh-release a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
   },
   "homepage": "https://github.com/Esri/configurable-app-components#readme",
   "devDependencies": {
+    "gh-release": "^3.5.0",
     "typescript": "^3.0.0",
     "@types/arcgis-js-api": "^4.11.0",
     "dojo-typings": "^1.11.9"
   },
-  "dependencies": {
-    "gh-release": "^3.5.0"
+  "peerDependencies": {
+    "arcgis-js-api": "^4.0.0"
   }
 }


### PR DESCRIPTION
downstream consumers of your package don't need to install `gh-release`, its tooling that helps you as a maintainer. this means it should be a [`devDependency`](https://docs.npmjs.com/files/package.json#devdependencies).

similarly, declaring `arcgis-js-api` as a [`peerDependency`](https://docs.npmjs.com/files/package.json#peerdependencies) is the best choice to express compatibility without being opinionated. 